### PR TITLE
Allow user to enter existing token to join a list

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,9 +13,11 @@ import Navigation from './components/Navigation';
 import Home from './components/Home';
 import getToken from './lib/tokens';
 import { FirebaseContext } from './components/Firebase';
+// import { useCollectionData } from 'react-firebase-hooks/firestore';
 
 function App() {
   const [userToken, setUserToken] = useState('');
+  const [alertMsg, setAlertMsg] = useState('');
   const firebase = useContext(FirebaseContext);
   const db = firebase.firestore();
 
@@ -49,6 +51,26 @@ function App() {
     }
   };
 
+  const submitListToken = (event) => {
+    event.preventDefault();
+    const listToken = event.target.listToken.value;
+    const list = db.collection(listToken);
+    list.get().then((doc) => {
+      if (!doc.empty) {
+        setUserToken(listToken.trim());
+        window.localStorage.setItem('shoppingListAppUser', listToken);
+      } else {
+        setAlertMsg({
+          message: 'Token does not exist. Please try again or create new list.',
+          msgType: 'danger',
+        });
+        setTimeout(() => {
+          setAlertMsg('');
+        }, 3000);
+      }
+    });
+  };
+
   return (
     <ThemeProvider theme={sketchy}>
       <header>Smart Shopping List</header>
@@ -73,7 +95,11 @@ function App() {
               {userToken ? (
                 <Redirect to="/list" />
               ) : (
-                <Home createUserToken={createUserToken} />
+                <Home
+                  createUserToken={createUserToken}
+                  submitListToken={submitListToken}
+                  alertMsg={alertMsg}
+                />
               )}
             </Route>
           </Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,6 @@ import Navigation from './components/Navigation';
 import Home from './components/Home';
 import getToken from './lib/tokens';
 import { FirebaseContext } from './components/Firebase';
-// import { useCollectionData } from 'react-firebase-hooks/firestore';
 
 function App() {
   const [userToken, setUserToken] = useState('');

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,18 +1,44 @@
-import React from 'react';
-import { Button } from 'theme-ui';
+import React, { useState } from 'react';
+import { Button, Label, Input, Box } from 'theme-ui';
 import PropTypes from 'prop-types';
+import Notification from './Notification';
 
-const Home = ({ createUserToken }) => {
+const Home = ({ createUserToken, submitListToken, alertMsg }) => {
+  const [listToken, setListToken] = useState('');
+
+  const onChangeListToken = (event) => {
+    setListToken(event.target.value);
+  };
+
   return (
     <div>
       <h1>Welcome!</h1>
       <Button onClick={createUserToken}>Create new list</Button>
+
+      <h3>OR</h3>
+      <p>Join an existing shopping list by entering a three word token</p>
+
+      {alertMsg && (
+        <Notification message={alertMsg.message} msgType={alertMsg.msgType} />
+      )}
+
+      <Box as="form" onSubmit={submitListToken}>
+        <Label htmlFor="listToken">Share token</Label>
+        <Input
+          mb={3}
+          id="listToken"
+          value={listToken}
+          onChange={onChangeListToken}
+        />
+        <Button type="submit">Join an existing item</Button>
+      </Box>
     </div>
   );
 };
 
 Home.propTypes = {
   createUserToken: PropTypes.func.isRequired,
+  submitListToken: PropTypes.func.isRequired,
 };
 
 export default Home;

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,11 @@ nav {
   margin: 0 auto;
 }
 
+main {
+  padding: 1rem;
+  text-align: center;
+}
+
 nav {
   text-align: center;
   padding: 1rem;


### PR DESCRIPTION
## Description

Add feature to allow users to enter a token to join an existing list.

## Related Issue

Closes #5 

## Acceptance Criteria

- [x] When the user does not already have a token in localStorage, on the onboarding/home screen, a simple form is displayed that allows the user to enter a token
- [x] Entering the token and hitting submit saves the token to localStorage, effectively giving them joint control of the list
- [x] On submit, show an error if the token does not exist
- [x] If they get an error message, allow them to try again or create a new list

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![yenly-smart-shopping-list netlify app_list(iphone 11)](https://user-images.githubusercontent.com/6759658/105560118-c9dec800-5cc7-11eb-920b-c9e93ebf05f4.png)

### After

![localhost_3000_(iphone 11)](https://user-images.githubusercontent.com/6759658/105560132-d8c57a80-5cc7-11eb-89cb-dcd0c9854177.png)


## Testing Steps / QA Criteria

1. Navigate to https://yenly-smart-shopping-list.netlify.app
2. Enter a three words token. Try any 3 words. Click **Join an existing list**
3. Red notification message "List does not exist. Try again or create a new list."
4. Enter a real list token, "rise false shady"
5. View should change to list view display list of items. Users can use Add item form to add to the list.

