### PR TITLE
Feat empty list prompt

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -34,13 +34,15 @@ const AddItem = ({ userToken, setAlertMsg }) => {
   };
 
   const isDuplicate = (itemName) => {
-    const name = itemName.toLowerCase().replace(/[\W]+/, '');
+    const regexPattern = /[\W]+/; // another pattern /[^a-zA-Z0-9]/g
+
+    const name = itemName.toLowerCase().replace(regexPattern, '');
     if (listItems.length === 0) {
       return false;
     }
     const parseList = listItems.filter((item) => {
-      const tempName = item.name.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
-      return tempName.includes(name);
+      const tempName = item.name.toLowerCase().replace(regexPattern, '');
+      return tempName.match(name);
     });
     return parseList.length !== 0;
   };
@@ -72,7 +74,7 @@ const AddItem = ({ userToken, setAlertMsg }) => {
             .catch((error) => console.error(`Error adding item: ${error}`));
           setAlertMsg({
             message: 'Item added!',
-            msgType: 'info',
+            msgType: 'success',
           });
           setItemName('');
           setLikelyToPurchange(7);

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -34,7 +34,7 @@ const AddItem = ({ userToken, setAlertMsg }) => {
   };
 
   const isDuplicate = (itemName) => {
-    const regexPattern = /[\W]+/; // another pattern /[^a-zA-Z0-9]/g
+    const regexPattern = /[\W\d_]*/g;
 
     const name = itemName.toLowerCase().replace(regexPattern, '');
     if (listItems.length === 0) {
@@ -42,7 +42,8 @@ const AddItem = ({ userToken, setAlertMsg }) => {
     }
     const parseList = listItems.filter((item) => {
       const tempName = item.name.toLowerCase().replace(regexPattern, '');
-      return tempName.match(name);
+      console.log({ tempName, name });
+      return tempName === name; //tempName.match(name);
     });
     return parseList.length !== 0;
   };

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -1,4 +1,5 @@
-import { Fragment } from 'react';
+// eslint-disable-next-line no-unused-vars
+import React, { Fragment } from 'react';
 import { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -1,4 +1,5 @@
-import { useContext, Fragment } from 'react';
+// eslint-disable-next-line no-unused-vars
+import React, { useContext, Fragment } from 'react';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
 import { FirebaseContext } from './Firebase';
 import PropTypes from 'prop-types';

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -1,9 +1,10 @@
-import React, { useContext } from 'react';
+import { useContext, Fragment } from 'react';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
 import { FirebaseContext } from './Firebase';
 import PropTypes from 'prop-types';
 /** @jsx jsx */
-import { jsx, Card } from 'theme-ui';
+import { jsx, Card, Button } from 'theme-ui';
+import { useHistory } from 'react-router-dom';
 
 const ListItems = ({ userToken }) => {
   const firebase = useContext(FirebaseContext);
@@ -16,17 +17,22 @@ const ListItems = ({ userToken }) => {
       },
     },
   );
+  let history = useHistory();
+
   if (!listItems) {
     return null;
   }
+
+  const handleOnClick = () => {
+    history.push('/add');
+  };
+
   return (
-    <>
+    <Fragment>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Loading list...</span>}
       {listItems && listItems.length !== 0 && (
         <Card
-          mb={5}
-          mt={10}
           sx={{
             maxWidth: 600,
             padding: '20px',
@@ -44,8 +50,13 @@ const ListItems = ({ userToken }) => {
           </ul>
         </Card>
       )}
-      {listItems.length === 0 && <p>Your shopping list is currently empty.</p>}
-    </>
+      {listItems.length === 0 && (
+        <>
+          <p>Your shopping list is currently empty.</p>
+          <Button onClick={handleOnClick}>Add item</Button>
+        </>
+      )}
+    </Fragment>
   );
 };
 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,10 +1,23 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
 
 const Navigation = () => {
+  let location = useLocation();
+
+  if (location.pathname === '/') {
+    return null;
+  }
+
   return (
-    <nav>
+    <nav
+      sx={{
+        border: 'thin',
+        borderColor: 'blueDark',
+        borderRadius: 'sketchy0',
+        background: (theme) => theme.colors.blue,
+      }}
+    >
       <NavLink to="/list" sx={{ variant: 'links.nav' }}>
         List
       </NavLink>

--- a/src/index.css
+++ b/src/index.css
@@ -37,8 +37,12 @@ main {
 }
 
 nav {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0.5rem;
   text-align: center;
   padding: 1rem;
+  width: 90%;
 }
 
 nav a {


### PR DESCRIPTION
## Description

- Add friendly prompt to add items when list is empty. 
- Clean up the layout and refactor regex pattern to not allow items entered as "Milk_1988"

## Related Issue

Closes #7 

## Acceptance Criteria

- [x] The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

## Testing Steps / QA Criteria

1. Navigate to https://yenly-smart-shopping-list.netlify.app
2. Create a new list, Users should see Add item button on list view.
3. Add "ice" cream to list, see confirmation and see item listed on list view
4. Add "ice" to list, see confirmation and see item listed on list view
5. Add "Ice!", see warning that ice is already on the list
6. Add "Ice_88", see warning that ice is already on the list 

