### PR TITLE
Allow user to mark item as purchased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5643,6 +5643,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theme-ui/components": "^0.3.5",
     "@theme-ui/presets": "^0.3.5",
+    "dayjs": "^1.10.4",
     "firebase": "^8.2.1",
     "husky": "^4.3.6",
     "lint-staged": "^10.5.3",

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -43,7 +43,6 @@ const AddItem = ({ userToken, setAlertMsg }) => {
     }
     const parseList = listItems.filter((item) => {
       const tempName = item.name.toLowerCase().replace(regexPattern, '');
-      console.log({ tempName, name });
       return tempName === name; //tempName.match(name);
     });
     return parseList.length !== 0;

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,12 @@ fieldset {
   border: 0;
 }
 
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
 .active {
   font-weight: bold;
 }


### PR DESCRIPTION
## Description
User can mark items purchased


## Related Issue

Closes #8 

## Acceptance Criteria

- [x] User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
- [x] Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After
<img width="298" alt="Screen Shot 2021-01-27 at 2 54 37 PM" src="https://user-images.githubusercontent.com/6759658/106065615-63cfb780-60b0-11eb-8aaf-121d0cab06c2.png">



## Testing Steps / QA Criteria
1. Navigate to https://yenly-smart-shopping-list.netlify.app
2. Create a new list or open an existing list by using the token "fox mount tuna"
3. Click on the checkbox on one item
4. Go add a new item
5. Noticed the checked item from step 3 is still checked
6. Step away from the app for a few hours, check if the checked item is still checked
7. Step away from the app for a day, check if the checked item is now unchecked.