### PR TITLE
Account for empty lists by saving new token to list for reference

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,12 @@ function App() {
 
   const createUserToken = () => {
     const newToken = getToken();
+    db.collection('listTokens')
+      .add({
+        token: newToken,
+      })
+      .then((docRef) => console.log(`New token added: ${docRef.id}`))
+      .catch((error) => console.error(`Error adding token: ${error}`));
     setUserToken(newToken);
     window.localStorage.setItem('shoppingListAppUser', newToken);
   };
@@ -37,7 +43,7 @@ function App() {
   const submitListToken = (event) => {
     event.preventDefault();
     const listToken = event.target.listToken.value;
-    const list = db.collection(listToken);
+    const list = db.collection('listTokens').where('token', '==', listToken);
     list.get().then((doc) => {
       if (!doc.empty) {
         setUserToken(listToken.trim());

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -58,6 +58,13 @@ const ListItems = ({ userToken }) => {
     <Fragment>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Loading list...</span>}
+      {userToken && (
+        <p>
+          Share your list with this token:
+          <br />
+          <strong>{userToken}</strong>
+        </p>
+      )}
       {listItems && listItems.length !== 0 && (
         <Card
           sx={{


### PR DESCRIPTION
## Description

Firebase can not create empty collections so the workaround is to store new tokens in a list to check against.

## Related Issue

Close #25 

## Acceptance Criteria

- [x] When the user creates a new token, users may share the empty list before adding items.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

