### PR TITLE
feat: Allow user to filter shopping list

### DIFF
--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -90,72 +90,74 @@ const ListItems = ({ userToken }) => {
           <strong>{userToken}</strong>
         </p>
       )}
-      <Label htmlFor="searchTerm">Filter items</Label>
-      <div className="searchTermInput">
-        <Input
-          mb={3}
-          name="searchTerm"
-          value={searchTerm}
-          onChange={handleSearchTermOnChange}
-        />
-        {displayClearIcon && (
-          <IconButton
-            aria-label="Clear Filter Term"
-            onClick={clearSearchTermInput}
-          >
-            X
-          </IconButton>
-        )}
-      </div>
 
       {listItems && listItems.length !== 0 && (
-        <Card
-          sx={{
-            maxWidth: 600,
-            padding: '20px',
-            border: 'thin',
-            borderColor: 'yellowDark',
-            borderRadius: 'sketchy5',
-            textAlign: 'left',
-            background: (theme) => theme.colors.yellow,
-          }}
-        >
-          <ul>
-            {listItems
-              .filter((item) => item.name.includes(searchTerm))
-              .map((item) => {
-                if (isWithinADay(item.purchaseDate)) {
-                  return (
-                    <li key={item.name}>
-                      <Label htmlFor={item.name} mb={2}>
-                        <Checkbox
-                          id={item.name}
-                          name={item.name}
-                          checked
-                          readOnly
-                        />
-                        {item.name}
-                      </Label>
-                    </li>
-                  );
-                } else {
-                  return (
-                    <li key={item.name}>
-                      <Label htmlFor={item.name} mb={2}>
-                        <Checkbox
-                          id={item.name}
-                          name={item.name}
-                          onClick={markPurchased}
-                          onChange={markPurchased}
-                        />
-                        {item.name}
-                      </Label>
-                    </li>
-                  );
-                }
-              })}
-          </ul>
-        </Card>
+        <>
+          <Label htmlFor="searchTerm">Filter items</Label>
+          <div className="searchTermInput">
+            <Input
+              mb={3}
+              name="searchTerm"
+              value={searchTerm}
+              onChange={handleSearchTermOnChange}
+            />
+            {displayClearIcon && (
+              <IconButton
+                aria-label="Clear Filter Term"
+                onClick={clearSearchTermInput}
+              >
+                X
+              </IconButton>
+            )}
+          </div>
+          <Card
+            sx={{
+              maxWidth: 600,
+              padding: '20px',
+              border: 'thin',
+              borderColor: 'yellowDark',
+              borderRadius: 'sketchy5',
+              textAlign: 'left',
+              background: (theme) => theme.colors.yellow,
+            }}
+          >
+            <ul>
+              {listItems
+                .filter((item) => item.name.includes(searchTerm))
+                .map((item) => {
+                  if (isWithinADay(item.purchaseDate)) {
+                    return (
+                      <li key={item.name}>
+                        <Label htmlFor={item.name} mb={2}>
+                          <Checkbox
+                            id={item.name}
+                            name={item.name}
+                            checked
+                            readOnly
+                          />
+                          {item.name}
+                        </Label>
+                      </li>
+                    );
+                  } else {
+                    return (
+                      <li key={item.name}>
+                        <Label htmlFor={item.name} mb={2}>
+                          <Checkbox
+                            id={item.name}
+                            name={item.name}
+                            onClick={markPurchased}
+                            onChange={markPurchased}
+                          />
+                          {item.name}
+                        </Label>
+                      </li>
+                    );
+                  }
+                })}
+            </ul>
+          </Card>
+        </>
       )}
       {listItems.length === 0 && (
         <>

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,15 @@ ul {
 .active {
   font-weight: bold;
 }
+
+.searchTermInput {
+  position: relative;
+}
+
+.searchTermInput button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0;
+  color: red;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Description
Allow users to use the input field to filter through shopping list items.


## Related Issue

Closes #9 

## Acceptance Criteria

- [x] Display a text field above the top of the shopping list
- [x] As the user types into the field, the list should narrow to display only items that contain the text the user entered in the filter field
- [x] When the field has text in it, the user should be able to tap a UI element (e.g., with an "X" button next to the field) to clear the field
- [x] The filter text should match any part of the item name (i.e. it should not only match from the start of the string)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After

<img width="298" alt="Screen Shot 2021-02-03 at 4 00 26 PM" src="https://user-images.githubusercontent.com/6759658/106825086-fcc67b80-6638-11eb-9d46-d7600839da7c.png">



## Testing Steps / QA Criteria

1. Navigate to https://yenly-smart-shopping-list.netlify.app
2. Enter token `arm game franc` to view an existing list
3. Enter filter term i.e. cream under **Filter items**
4. Observe list changes to display only items with 'cream' as part of word(s)

