### PR TITLE
Feat estimate next purchase

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -56,7 +56,7 @@ const AddItem = ({ userToken, setAlertMsg }) => {
       const newItem = {
         name: itemName.trim(),
         likelyToPurchase: likelyToPurchase,
-        purchaseDate: null,
+        purchaseDates: [],
       };
       if (userToken) {
         if (isDuplicate(itemName)) {

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -54,12 +54,14 @@ const ListItems = ({ userToken }) => {
           const now = dayjs();
           let item = doc.data();
           let purchaseDates = item.purchaseDates;
-          let latestInterval = '';
-          if (item.purchaseDates.length > 2) {
-            latestInterval = calculateLastInterval(item.purchaseDates);
-          } else {
-            latestInterval = item.likelyToPurchase;
-          }
+          const latestInterval =
+            item.purchaseDates.length >= 1
+              ? calculateLastInterval(
+                  purchaseDates[purchaseDates.length - 1],
+                  now.valueOf(),
+                )
+              : item.likelyToPurchase;
+
           purchaseDates =
             purchaseDates.length === 0
               ? (purchaseDates = [now.valueOf()])
@@ -74,6 +76,7 @@ const ListItems = ({ userToken }) => {
             latestInterval,
             numberOfPurchases,
           );
+
           const itemDocRef = db.collection(userToken).doc(doc.id);
           itemDocRef.update({
             purchaseDates: purchaseDates,
@@ -84,10 +87,10 @@ const ListItems = ({ userToken }) => {
       .catch((error) => console.error(error));
   };
 
-  const calculateLastInterval = (purchases) => {
-    const mostRecent = dayjs(purchases[purchases.length - 1]);
-    const secondToLast = dayjs(purchases[purchases.length - 2]);
-    const duration = dayjs.duration(mostRecent.diff(secondToLast));
+  const calculateLastInterval = (lastPurchase, today) => {
+    const mostRecent = dayjs(lastPurchase);
+    const todayPurchase = dayjs(today);
+    const duration = dayjs.duration(todayPurchase.diff(mostRecent));
     return Math.round(duration.asDays());
   };
 
@@ -163,36 +166,51 @@ const ListItems = ({ userToken }) => {
                 .filter((item) => item.name.includes(searchTerm))
                 .map((item) => {
                   // console.log(item.name, isWithinADay(item.purchaseDates.pop()))
-                  if (isWithinADay(item.purchaseDates.pop())) {
-                    return (
-                      <li key={item.name}>
-                        <Label htmlFor={item.name} mb={2}>
-                          <Checkbox
-                            id={item.name}
-                            name={item.name}
-                            onChange={markPurchased}
-                            checked
-                            readOnly
-                          />
-                          {item.name}
-                        </Label>
-                      </li>
-                    );
-                  } else {
-                    return (
-                      <li key={item.name}>
-                        <Label htmlFor={item.name} mb={2}>
-                          <Checkbox
-                            id={item.name}
-                            name={item.name}
-                            onClick={markPurchased}
-                            onChange={markPurchased}
-                          />
-                          {item.name}
-                        </Label>
-                      </li>
-                    );
-                  }
+                  // if (isWithinADay(item.purchaseDates.pop())) {
+                  //   return (
+                  //     <li key={item.name}>
+                  //       <Label htmlFor={item.name} mb={2}>
+                  //         <Checkbox
+                  //           id={item.name}
+                  //           name={item.name}
+                  //           onChange={markPurchased}
+                  //           checked={true}
+                  //           readOnly
+                  //         />
+                  //         {item.name}
+                  //       </Label>
+                  //     </li>
+                  //   );
+                  // } else {
+                  //   return (
+                  //     <li key={item.name}>
+                  //       <Label htmlFor={item.name} mb={2}>
+                  //         <Checkbox
+                  //           id={item.name}
+                  //           name={item.name}
+                  //           onClick={markPurchased}
+                  //           onChange={markPurchased}
+                  //         />
+                  //         {item.name}
+                  //       </Label>
+                  //     </li>
+                  //   );
+                  // }
+                  return (
+                    <li key={item.name}>
+                      <Label htmlFor={item.name} mb={2}>
+                        <Checkbox
+                          id={item.name}
+                          name={item.name}
+                          onClick={markPurchased}
+                          onChange={markPurchased}
+                          checked={isWithinADay(item.purchaseDates.pop())}
+                          readOnly={isWithinADay(item.purchaseDates.pop())}
+                        />
+                        {item.name}
+                      </Label>
+                    </li>
+                  );
                 })}
             </ul>
           </Card>

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import React, { useContext, Fragment, useState, isValidElement } from 'react';
+import React, { useContext, Fragment, useState } from 'react';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
 import { FirebaseContext } from './Firebase';
 import PropTypes from 'prop-types';
@@ -58,7 +58,7 @@ const ListItems = ({ userToken }) => {
           // undo checked box and revert data by
           //   remove last purchase date
           //   change estimatedDays = lastEstimate, lastEstimate = null
-          // }
+          // } else do calculate estimate and save purchase date
           const latestInterval =
             item.purchaseDates.length >= 1
               ? calculateLastInterval(

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -48,16 +48,23 @@ const ListItems = ({ userToken }) => {
       .then((querySnapshot) => {
         querySnapshot.forEach((doc) => {
           const now = dayjs();
+          let item = doc.data();
+          let purchaseDates = item.purchaseDates;
+          purchaseDates =
+            purchaseDates.length === 0
+              ? (purchaseDates = [now.valueOf()])
+              : [now.valueOf(), ...purchaseDates];
           const itemDocRef = db.collection(userToken).doc(doc.id);
-          itemDocRef.update({
-            purchaseDate: now.valueOf(),
-          });
+          itemDocRef.update({ purchaseDates: purchaseDates });
         });
       })
       .catch((error) => console.error(error));
   };
 
   const isWithinADay = (pDate) => {
+    if (pDate === undefined) {
+      return false;
+    }
     const purchaseDate = dayjs(pDate);
     const today = dayjs();
     const cDate = purchaseDate.add(24, 'hour');
@@ -125,7 +132,8 @@ const ListItems = ({ userToken }) => {
               {listItems
                 .filter((item) => item.name.includes(searchTerm))
                 .map((item) => {
-                  if (isWithinADay(item.purchaseDate)) {
+                  // console.log(item.name, isWithinADay(item.purchaseDates.pop()))
+                  if (isWithinADay(item.purchaseDates.pop())) {
                     return (
                       <li key={item.name}>
                         <Label htmlFor={item.name} mb={2}>

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -54,22 +54,21 @@ const ListItems = ({ userToken }) => {
           const now = dayjs();
           let item = doc.data();
           let purchaseDates = item.purchaseDates;
-          const lastPurchaseDate = dayjs(
-            Number(item.purchaseDates[item.purchaseDates.length - 1]),
-          );
+          let latestInterval = '';
+          if (item.purchaseDates.length > 2) {
+            latestInterval = calculateLastInterval(item.purchaseDates);
+          } else {
+            latestInterval = item.likelyToPurchase;
+          }
           purchaseDates =
             purchaseDates.length === 0
               ? (purchaseDates = [now.valueOf()])
               : [...purchaseDates, now.valueOf()];
 
-          // calculate estimated number of days until the next purchase date
-          // need: lastEstimate, latestInterval, numberOfPurchases
           const lastEstimate = !isNaN(item.lastEstimate)
             ? item.lastEstimate
             : null;
           const numberOfPurchases = purchaseDates.length;
-          const duration = dayjs.duration(now.diff(lastPurchaseDate));
-          const latestInterval = Math.round(duration.asDays());
           const newEstimate = calculateEstimate(
             lastEstimate,
             latestInterval,
@@ -83,6 +82,13 @@ const ListItems = ({ userToken }) => {
         });
       })
       .catch((error) => console.error(error));
+  };
+
+  const calculateLastInterval = (purchases) => {
+    const mostRecent = dayjs(purchases[purchases.length - 1]);
+    const secondToLast = dayjs(purchases[purchases.length - 2]);
+    const duration = dayjs.duration(mostRecent.diff(secondToLast));
+    return Math.round(duration.asDays());
   };
 
   const isWithinADay = (pDate) => {

--- a/src/lib/dateDurations.js
+++ b/src/lib/dateDurations.js
@@ -1,0 +1,25 @@
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+dayjs.extend(duration);
+
+// param: pDate in milliseconds
+// return: duration object
+export const calculateDateDuration = (pDate) => {
+  if (pDate === undefined) {
+    return false;
+  }
+  const purchaseDate = dayjs(pDate);
+  const today = dayjs();
+  const duration = dayjs.duration(today.diff(purchaseDate));
+  return duration;
+};
+
+export const isWithinADay = (pDate) => {
+  const duration = calculateDateDuration(pDate);
+  return Math.round(duration.asMinutes()) < 60;
+};
+
+export const isWithinMinutes = (pDate) => {
+  const duration = calculateDateDuration(pDate);
+  return Math.round(duration.asMinutes()) <= 5;
+};


### PR DESCRIPTION
## Description

- Calculate estimated number of days until next purcahse date and store value in database.
- Check date/time duration to allow the users to uncheck item if it's within minutes of checking an item off

## Related Issue

Closes #10 

## Acceptance Criteria

- [x] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database
- [x] User can uncheck item if it is within five minutes of checking off an item 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates


## Testing Steps / QA Criteria

1. Navigate to yenly-smart-shopping-list.netlify.app
2. Create a new list or join `fork noel rotor`

3. Test if marking item, will calculate estimatedDays to next purchase and save relevant data to the database
 - check unchecked item on the list,
 - log in to console.firebase.com, open database, verify the item has a new purchase date now have estimatedDays, lastEstimates fields.

4. Test if the user can undo checked item within 5 minutes window
 - click on the checked item from above, verify on console.firebase.com the new purchase date is deleted and changes to estimatedDays and lastEstimates fields revert to previous values

5. Test if the user can undo checked item after waiting for more than 5 minutes
- check an unchecked item on the list,
- wait for more than 5 minutes, try clicking on the checked item from the last step
- verify checkbox should be disabled

