### PR TITLE
Feat sort list order

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -57,6 +57,8 @@ const AddItem = ({ userToken, setAlertMsg }) => {
         name: itemName.trim(),
         likelyToPurchase: likelyToPurchase,
         purchaseDates: [],
+        lastEstimates: null,
+        estimatedDays: null,
       };
       if (userToken) {
         if (isDuplicate(itemName)) {

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -58,7 +58,6 @@ const AddItem = ({ userToken, setAlertMsg }) => {
         likelyToPurchase: likelyToPurchase,
         purchaseDates: [],
         lastEstimates: null,
-        estimatedDays: null,
       };
       if (userToken) {
         if (isDuplicate(itemName)) {

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -163,15 +163,17 @@ const ListItems = ({ userToken, deleteItem }) => {
     }
   };
 
+  // TODO: redefine inactive criteria in accordance to COVID shopping habits
   const isInactive = (item) => {
     const lastPurchaseDate = dayjs(
       item.purchaseDates[item.purchaseDates.length - 1],
     );
     const duration = calculateDateDuration(lastPurchaseDate);
     const daysSincePurchase = Math.round(duration.asDays());
+    console.log(item.name, { daysSincePurchase }, item.likelyToPurchase);
     return (
       item.purchaseDates.length === 1 &&
-      daysSincePurchase >= item.likelyToPurchase
+      daysSincePurchase * 2 >= item.likelyToPurchase
     );
   };
 
@@ -243,7 +245,7 @@ const ListItems = ({ userToken, deleteItem }) => {
                             id={item.name}
                             name={item.name}
                             aria-label={itemStatus}
-                            onClick={markPurchased}
+                            onClick={markPurchased} // for older verions of IE
                             onChange={markPurchased}
                             checked={isChecked(item.purchaseDates)}
                             disabled={isDisabled(item.purchaseDates)}

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -173,7 +173,7 @@ const ListItems = ({ userToken, deleteItem }) => {
     console.log(item.name, { daysSincePurchase }, item.likelyToPurchase);
     return (
       item.purchaseDates.length === 1 &&
-      daysSincePurchase * 2 >= item.likelyToPurchase
+      daysSincePurchase >= item.likelyToPurchase * 2
     );
   };
 

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -150,6 +150,33 @@ const ListItems = ({ userToken, deleteItem }) => {
     );
   };
 
+  const howSoon = (days) => {
+    switch (true) {
+      case days <= 7:
+        return 'soon';
+      case days > 7 && days <= 30:
+        return 'kind-of-soon';
+      case days > 30:
+        return 'not-soon';
+      default:
+        return;
+    }
+  };
+
+  const isInactive = (item) => {
+    if (item.estimatedDays === null) {
+      return false;
+    }
+    const lastPurchaseDate = dayjs(
+      item.purchaseDates[item.purchaseDates.length - 1],
+    );
+    const duration = calculateDateDuration(lastPurchaseDate);
+    const daysSincePurchase = Math.round(duration.asDays());
+    return (
+      item.purchaseDates.length === 1 && daysSincePurchase >= item.estimatedDays
+    );
+  };
+  // console.log({listItems})
   return (
     <Fragment>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
@@ -196,13 +223,24 @@ const ListItems = ({ userToken, deleteItem }) => {
               {listItems
                 .filter((item) => item.name.includes(searchTerm))
                 .map((item) => {
+                  let itemStatus = '';
+                  if (isInactive(item)) {
+                    itemStatus = 'inactive';
+                  } else {
+                    itemStatus = howSoon(item.estimatedDays);
+                  }
                   return (
                     <li key={item.name}>
                       <Flex>
-                        <Label htmlFor={item.name} mb={2}>
+                        <Label
+                          aria-label={itemStatus}
+                          htmlFor={item.name}
+                          mb={2}
+                        >
                           <Checkbox
                             id={item.name}
                             name={item.name}
+                            aria-label={itemStatus}
                             onClick={markPurchased}
                             onChange={markPurchased}
                             checked={isChecked(item.purchaseDates)}

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -152,12 +152,13 @@ const ListItems = ({ userToken, deleteItem }) => {
 
   const howSoon = (days) => {
     switch (true) {
+      case days == null:
+      case days > 30:
+        return 'not-soon';
       case days <= 7:
         return 'soon';
       case days > 7 && days <= 30:
         return 'kind-of-soon';
-      case days > 30:
-        return 'not-soon';
       default:
         return;
     }

--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -170,17 +170,23 @@ const ListItems = ({ userToken, deleteItem }) => {
     );
     const duration = calculateDateDuration(lastPurchaseDate);
     const daysSincePurchase = Math.round(duration.asDays());
-    console.log(item.name, { daysSincePurchase }, item.likelyToPurchase);
     return (
-      item.purchaseDates.length === 1 &&
+      item.purchaseDates.length === 1 ||
       daysSincePurchase >= item.likelyToPurchase * 2
     );
   };
 
   const sortedItems = listItems.sort((a, b) => {
-    return a.likelyToPurchase - b.likelyToPurchase;
+    switch (true) {
+      case !isInactive(a) && isInactive(b):
+        return 1;
+      case isInactive(a) && !isInactive(b):
+        return 1;
+      default:
+        return a.likelyToPurchase - b.likelyToPurchase;
+    }
   });
-  console.log({ sortedItems });
+
   return (
     <Fragment>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}

--- a/src/index.css
+++ b/src/index.css
@@ -78,3 +78,23 @@ ul {
 .delete {
   font-size: 0.85rem;
 }
+
+[aria-label='soon']::before {
+  content: '* ';
+  color: red;
+}
+
+[aria-label='kind-of-soon']::before {
+  content: '* ';
+  color: orange;
+}
+
+[aria-label='not-soon']::before {
+  content: '* ';
+  color: yellowgreen;
+}
+
+[aria-label='inactive']::before {
+  content: '* ';
+  color: lightgray;
+}


### PR DESCRIPTION
## Description
Display list in order of how soon user is likely to buy each item. Color code red for soon, orange for kind of soon, yellow-green for not soon, grey for inactive items. 


## Related Issue

Closes #12 

## Acceptance Criteria
- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [x] Items should be sorted by the estimated number of days until next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After

<!-- If UI feature, take provide screenshots -->
<img width="360" alt="Screen Shot 2021-02-15 at 8 03 33 PM" src="https://user-images.githubusercontent.com/6759658/108017137-02bd4480-6fc9-11eb-8e50-30f80c6ab28a.png">

## Testing Steps / QA Criteria
1. navigate to https://yenly-smart-shopping-list.netlify.app/
2. open an existing one with token fork noel rotor
3. check item off list and observe color change when the estimate of likely to purchase changes. 
4. check an inactive item and observe the color change based on estimate of likely to purchase.



