### PR TITLE
Fix inactive logic and sorting conditions

### DIFF
--- a/src/components/ListItems.js
+++ b/src/components/ListItems.js
@@ -57,7 +57,7 @@ const ListItems = ({ userToken, deleteItem }) => {
           const now = dayjs();
           let item = doc.data();
           let purchaseDates = item.purchaseDates;
-          // if(purchaseDates && isWithinMinutes(purchaseDates[purchaseDates.length - 1])) {
+          // if(purchaseDates exists and last purchaseDate is within 5 minutes to now) {
           // undo checked box and revert data by
           //   remove last purchase date
           //   change likelyToPurchase = lastEstimate, lastEstimate = null
@@ -98,7 +98,7 @@ const ListItems = ({ userToken, deleteItem }) => {
               latestInterval,
               numberOfPurchases,
             );
-            // save to lastEstimate to list of lastEstimates for reverting
+            // save lastEstimate to list of lastEstimates for reverting
             const lastEstimates =
               item.lastEstimates && item.lastEstimates.length !== 0
                 ? [...item.lastEstimates, lastEstimate]
@@ -149,7 +149,6 @@ const ListItems = ({ userToken, deleteItem }) => {
     );
   };
 
-  // if null, set new label instead
   const howSoon = (days) => {
     switch (true) {
       case days <= 7:
@@ -170,8 +169,9 @@ const ListItems = ({ userToken, deleteItem }) => {
     );
     const duration = calculateDateDuration(lastPurchaseDate);
     const daysSincePurchase = Math.round(duration.asDays());
+
     return (
-      item.purchaseDates.length === 1 ||
+      item.purchaseDates.length === 1 &&
       daysSincePurchase >= item.likelyToPurchase * 2
     );
   };
@@ -179,7 +179,7 @@ const ListItems = ({ userToken, deleteItem }) => {
   const sortedItems = listItems.sort((a, b) => {
     switch (true) {
       case !isInactive(a) && isInactive(b):
-        return 1;
+        return -1;
       case isInactive(a) && !isInactive(b):
         return 1;
       default:


### PR DESCRIPTION
## Description
Changed the inactive criteria to meet two conditions: 1. 1 purchase date, 2. last purchase date is longer than 2x the estimated likely to purchase days

## Related Issue

Closes #35 

## Acceptance Criteria

- [x] Items with one purchase date and date is  older than 2x the likely to purchase estimate days should be marked as inactive
- [x] Inactive items should be at the end of the list

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Testing Steps / QA Criteria

1. Navigate to https://yenly-smart-shopping-list.netlify.app/list
2. Use existing token `avis ivy stall`
3. Check off item, then log into firebase console to change date to be longer than likelyToPurchase days.
4. Item should have grey asteriks and moved to the bottom of the list

